### PR TITLE
force refresh when 3rd retry fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ RemoteObjectTemplate.processMessage = function(remoteCall, subscriptionId, resto
                     return Q.delay(callContext.retries * 1000).then(retryCall.bind(this));
                 } else {
                     this.log(1, "Update Conflict" + remoteCall.name+ "[" + remoteCall.sequence + "] - failed " + logTime());
-                    packageChanges.call(this, {type: 'retry', sync: false, remoteCallId: remoteCallId});
+                    packageChanges.call(this, {type: 'refresh', sync: false, remoteCallId: remoteCallId});
                 }
             } else {
                 this.log(1, "replying to " + remoteCall.name + " [" + remoteCall.sequence + "] error " + err.toString() + logTime());


### PR DESCRIPTION
Idea to prevent infinite loops on Update Conflicts - if type is `refresh`, then amorphic client.js will call `self._reset(message);`
