### PR TITLE
Transient fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+## 2.3.5
+* Further fix (started in 2.3.2) to ensure array references for existing non-transient objects are recorded
+* Fix to avoid accumulating \__referencedObjects\__ for transient objects to avoid serialization errors. 
 ## 2.3.4
 * Fixed issue where changes received in browser inadvertently turned around to server
 ## 2.3.3

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "semotus",
     "description": "A subclass of supertype that synchronizes sets of objects.",
     "homepage": "https://github.com/selsamman/semotus",
-    "version": "2.3.4",
+    "version": "2.3.5",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.*"


### PR DESCRIPTION
This has one additional change from the one we diagnosed with Ravi.  I noticed that when looking to log changes owing to array reference changes that we were testing on the __transient__ ObjectTemplate flag in addition to the object flag.  I removed the former just as we did for individual properties.