### PR TITLE
Enhanced change validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,14 +480,16 @@ RemoteObjectTemplate.processMessage = function processMessage(remoteCall, subscr
     function applyChangesAndValidateCall() {
         this.logger.info({component: 'semotus', module: 'processMessage', activity: 'call',
             data:{call: remoteCall.name, sequence: remoteCall.sequence, remoteCallId: remoteCall.id}}, remoteCall.name);
-
-        if (this._applyChanges(JSON.parse(remoteCall.changes), this.role == 'client', subscriptionId)) {
+        var changes = JSON.parse(remoteCall.changes);
+        if (this._applyChanges(changes, this.role == 'client', subscriptionId)) {
             var obj = session.objects[remoteCall.id];
 
             if (!obj) {
                 throw new Error('Cannot find object for remote call ' + remoteCall.id);
             }
-
+            if (this.role == 'server' && this.controller['validateServerIncomingObjects']) {
+                this.controller.validateServerIncomingObjects(changes, callContext);
+            }
             if (this.role == 'server' && obj['validateServerCall']) {
                 return obj['validateServerCall'].call(obj, remoteCall.name, callContext);
             }
@@ -1819,14 +1821,14 @@ RemoteObjectTemplate._applyObjectChanges = function applyObjectChanges(changes, 
         var defineProperty = this._getDefineProperty(prop, obj.__template__);
 
         if (!defineProperty) {
-            this.logger.error({component: 'semotus', module: 'applyObjectChanges', activity: 'processing', data:{template: obj.__template__.__name__, property: prop}},
+            this.logger.error({component: 'semotus', module: 'applyObjectChanges', activity: 'processing',
+                    data:{template: obj.__template__.__name__, property: prop}},
                 'Could not apply change to ' + obj.__template__.__name__ + '.' + prop + ' property not defined in template');
-
             return false;
-
         }
 
         if (defineProperty.type === Array) {
+            this._validateServerIncomingProperty(obj, prop, defineProperty, newValue)
             if (newValue instanceof Array) {
                 if (!(obj[prop] instanceof Array)) {
                     obj[prop] = [];
@@ -1846,21 +1848,6 @@ RemoteObjectTemplate._applyObjectChanges = function applyObjectChanges(changes, 
 
                 for (var ix = 0; ix < length; ++ix) {
                     var unarray_newValue = unarray(newValue[ix]);
-                    var validator = obj && (obj['validateServerIncomingProperty'] || this.controller['validateServerIncomingProperty']);
-
-                    var validatorThis;
-
-                    if (obj && obj['validateServerIncomingProperty']) {
-                        validatorThis = obj;
-                    }
-                    else {
-                        validatorThis = this.controller;
-                    }
-
-                    if (validator) {
-                        validator.call(validatorThis, obj, prop, ix, defineProperty, unarray_newValue);
-                    }
-
                     if (oldValue) {
                         if (!this._applyPropertyChange(changes, rollback, obj, prop, ix, unarray(oldValue[ix]), unarray_newValue, force)) {
                             return false;
@@ -1884,6 +1871,7 @@ RemoteObjectTemplate._applyObjectChanges = function applyObjectChanges(changes, 
             }
         }
         else { //TODO: make this into one elseif
+            this._validateServerIncomingProperty(obj, prop, defineProperty, newValue)
             if (!this._applyPropertyChange(changes, rollback, obj, prop, -1, oldValue, newValue, force)) {
                 return false;
             }
@@ -1906,7 +1894,25 @@ RemoteObjectTemplate._applyObjectChanges = function applyObjectChanges(changes, 
         }
     }
 };
+RemoteObjectTemplate._validateServerIncomingProperty = function (obj, prop, defineProperty, newValue) {
+    var validator = obj && (obj['validateServerIncomingProperty'] ||
+        this.controller['validateServerIncomingProperty']);
 
+    var validatorThis;
+
+    if (obj && obj['validateServerIncomingProperty']) {
+        validatorThis = obj;
+    }
+    else {
+        validatorThis = this.controller;
+    }
+
+    if (validator) {
+        validator.call(validatorThis, obj, prop, defineProperty, newValue);
+    }
+
+
+}
 /**
  * Apply changes for a specific property, cascading changes in the event
  * that a reference to an object that needs to be created is part of the change

--- a/test/semotus.js
+++ b/test/semotus.js
@@ -214,6 +214,8 @@ fromAccount.fromAccountTransactions.push(this);
         sam:     {type: Customer},
         karen:   {type: Customer},
         ashling: {type: Customer},
+        modPropString: {type: String},
+        modPropArray: {type: Array, of: String},
         init: function () {
 
             // Setup customers and addresses
@@ -342,19 +344,83 @@ describe('Banking Example', function () {
                 done(e);
             });
     });
-    it('can get a synchronization error', function (done) {
-        serverAssert = function () {
+    it('can get a validateServerIncomingProperty Scalar', function (done) {
+        serverAssert = function () {}
+        serverController.validateServerIncomingProperty = function (obj, prop, defineProperty, val) {
+            expect(obj.__template__.__name__).to.equal('Controller');
+            expect(prop).to.equal('modPropString');
+            expect(defineProperty.type).to.equal(String)
+            expect(val).to.equal('opps');
             throw 'get stuffed';
-        };
+        }
+        clientController.modPropString = 'opps';
         clientController.mainFunc()
             .then(function () {
                 expect('Should not be here').to.equal(false);
             }, function (e) {
                 expect(e.message).to.equal('get stuffed');
-                done();
+                serverController.validateServerIncomingProperty = null;
+                    done();
             }).fail(function(e) {
                 done(e);
             });
+    });
+    it('can get a validateServerIncomingProperty Array', function (done) {
+        serverAssert = function () {}
+        serverController.validateServerIncomingProperty = function (obj, prop, defineProperty, val) {
+            expect(obj.__template__.__name__).to.equal('Controller');
+            expect(prop).to.equal('modPropArray');
+            expect(defineProperty.type).to.equal(Array)
+            expect(val.length).to.equal(0);
+            throw 'get stuffed';
+        }
+        clientController.modPropArray = [];
+        clientController.mainFunc()
+            .then(function () {
+                expect('Should not be here').to.equal(false);
+            }, function (e) {
+                expect(e.message).to.equal('get stuffed');
+                serverController.validateServerIncomingProperty = null;
+                done();
+            }).fail(function(e) {
+            done(e);
+        });
+    });
+    it('can get a validateServerIncomingObject', function (done) {
+        serverAssert = function () {}
+        serverController.validateServerIncomingObject = function (obj) {
+            expect(obj.__template__.__name__).to.equal('Controller');
+            throw 'get stuffed';
+        }
+        clientController.modPropString = 'opps2';
+        clientController.mainFunc()
+            .then(function () {
+                expect('Should not be here').to.equal(false);
+            }, function (e) {
+                expect(e.message).to.equal('get stuffed');
+                serverController.validateServerIncomingObject = null;
+                done();
+            }).fail(function(e) {
+            done(e);
+        });
+    });
+    it('can get a validateServerIncomingObjects', function (done) {
+        serverAssert = function () {}
+        serverController.validateServerIncomingObjects = function (changes) {
+            expect(changes['client-Controller-1'].modPropString[1]).to.equal('opps3');
+            throw 'get stuffed';
+        }
+        clientController.modPropString = 'opps3';
+        clientController.mainFunc()
+            .then(function () {
+                expect('Should not be here').to.equal(false);
+            }, function (e) {
+                expect(e.message).to.equal('get stuffed');
+                serverController.validateServerIncomingObjects = null;
+                done();
+            }).fail(function(e) {
+            done(e);
+        });
     });
     it('can get a synchronization error from overlapping calls', function (done) {
         this.timeout(7000);


### PR DESCRIPTION
I did not add a comment to the change history so this would not conflict after merging 2.3.5.  The comment should be

2.3.5
* Added controller level serverValidateIncomingObjects which is passed changes and can throw and exception
* Fixed calls for serverValidateIncomingProperty which was not being called in all circumstances