### PR TITLE
Restoring expired controller from the session should not set the __changed__ flag on the objects.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+## 2.3.6
+* Fix to not set __changed__ flag for the objects when restoring the controller from the session
+* if the controller expired in the cache
 ## 2.3.5
 * Further fix (started in 2.3.2) to ensure array references for existing non-transient objects are recorded
 * Fix to avoid accumulating \__referencedObjects\__ for transient objects to avoid serialization errors. 

--- a/index.js
+++ b/index.js
@@ -2234,6 +2234,11 @@ RemoteObjectTemplate._createEmptyObject = function createEmptyObject(template, o
         }
 
         newValue = new template();  // _stashObject will assign this.nextDispenseId if present
+
+        if (!this.__changeTracking__) {
+            newValue.__changed__ = false;
+        }
+
         this.__transient__ = wasTransient;
 
         if (isTransient) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "semotus",
     "description": "A subclass of supertype that synchronizes sets of objects.",
     "homepage": "https://github.com/selsamman/semotus",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.*"


### PR DESCRIPTION
Chris,
We can use this fix to address the current controller cache expiration issues..

Sam,
To give you some background, in postserver controller call, we are seeing all the objects as changed if we are restoring the controller from the session. We restore the controller from the session if the controller has been cleared from the cache based on objectCacheSeconds config  setting, this is causing several update conflict issues and in some scenarios we are getting into looping issues.

Thanks,
Ravi